### PR TITLE
Fixes #2 - Handle cases where "errors" in weighting cause undesirable results

### DIFF
--- a/ChannelWidthWeighting.py
+++ b/ChannelWidthWeighting.py
@@ -56,6 +56,17 @@ def getCrossCorrelationCoefficient(regressionRegionCode, code1, code2):
     finally: 
         return coefficient
 
+#Check if the weighted estimate is within the bounds of input values
+def getWeightingErrorMessage(Z, x1, x2, x3 = None):
+    #Z is weighted estimate in log units
+    #x1, x2, x3 are input estimates in log units
+    if x3 == None:
+        x3 = x1
+    if ((Z < min(x1, x2, x3)) | (Z > max(x1, x2, x3))):
+        return "Weighted value is outside the range of input values. This can occur when the input estimates are highly correlated."
+    else:
+        return None
+
 def weightEst2(x1, x2, SEP1, SEP2, regressionRegionCode, code1, code2):
     #x1, x2 are input estimates in log units
 	#SEP1, SEP2 are input SEPs in log units
@@ -112,14 +123,3 @@ def weightEst3(x1, x2, x3, SEP1, SEP2, SEP3, regressionRegionCode, code1, code2,
     warningMessage = getWeightingErrorMessage(Z, x1, x2, x3)
 
     return((Z, SEPZ, warningMessage)) #Returns weighted estimate Z, and associated SEP
-
-#Check if the weighted estimate is within the bounds of input values
-def getWeightingErrorMessage(Z, x1, x2, x3 = None):
-    #Z is weighted estimate in log units
-    #x1, x2, x3 are input estimates in log units
-    if x3 == None:
-        x3 = x1
-    if ((Z < min(x1, x2, x3)) | (Z > max(x1, x2, x3))):
-        return "Weighted value is outside the range of input values. This can occur when the input estimates are highly correlated."
-    else:
-        return None

--- a/ChannelWidthWeighting.py
+++ b/ChannelWidthWeighting.py
@@ -75,7 +75,9 @@ def weightEst2(x1, x2, SEP1, SEP2, regressionRegionCode, code1, code2):
     Z = a1*x1 + a2*x2 #EQ 11
     SEPZ = ((SEP1**2*SEP2**2 - S12**2) / (SEP1**2 + SEP2**2 - 2*S12))**0.5 #EQ 12
 
-    return((Z, SEPZ)) #Returns weighted estimate Z, and associated SEP
+    warningMessage = getWeightingErrorMessage(Z, x1, x2)
+
+    return((Z, SEPZ, warningMessage)) #Returns weighted estimate Z, and associated SEP
 
 
 def weightEst3(x1, x2, x3, SEP1, SEP2, SEP3, regressionRegionCode, code1, code2, code3):
@@ -104,15 +106,20 @@ def weightEst3(x1, x2, x3, SEP1, SEP2, SEP3, regressionRegionCode, code1, code2,
     a3 = 1 - a1 - a2 #EQ 8
 
     Z = a1*x1 + a2*x2 + a3*x3 #EQ 5
-                                
+
     SEPZ = ((a1*SEP1)**2 + (a2*SEP2)**2 + (a3*SEP3)**2 + 2*a1*a2*S12 + 2*a1*a3*S13 + 2*a2*a3*S23)**0.5 #EQ 10
 
-    return((Z, SEPZ)) #Returns weighted estimate Z, and associated SEP
+    warningMessage = getWeightingErrorMessage(Z, x1, x2, x3)
+
+    return((Z, SEPZ, warningMessage)) #Returns weighted estimate Z, and associated SEP
 
 #Check if the weighted estimate is within the bounds of input values
-def weightingError(Z, x1, x2, x3 = None):
+def getWeightingErrorMessage(Z, x1, x2, x3 = None):
     #Z is weighted estimate in log units
     #x1, x2, x3 are input estimates in log units
     if x3 == None:
         x3 = x1
-    return ((Z < min(x1, x2, x3)) | (Z > max(x1, x2, x3)))
+    if ((Z < min(x1, x2, x3)) | (Z > max(x1, x2, x3))):
+        return "Weighted value is outside the range of input values. This can occur when the input estimates are highly correlated."
+    else:
+        return None

--- a/ChannelWidthWeighting.py
+++ b/ChannelWidthWeighting.py
@@ -1,4 +1,3 @@
-import warnings
 from coefficient_table import crossCorrelationCoefficientTable
 from hydrologic_region_table import hydrologicRegionsTable
 
@@ -9,7 +8,7 @@ def getCrossCorrelationCoefficient(regressionRegionCode, code1, code2):
     #code1, code2 ares the string codes that describes the flow statistic for the estimation methods, ex. "ACPK0_2AEP", which represents "Active Channel Width 0.2-percent AEP flood"
 
     if code1 == code2:
-        raise Exception("code1 and code2 must be different")
+        raise ValueError("codes must all be unique")
 
     #Determine hydrologic region that contains this Regression Region
     hydrologicRegionName = None
@@ -17,7 +16,7 @@ def getCrossCorrelationCoefficient(regressionRegionCode, code1, code2):
         if regressionRegionCode in regressionRegionCodes:
             hydrologicRegionName = hydrologicRegion
     if hydrologicRegionName == None:
-        raise Exception("Regression region code not valid")
+        raise ValueError("regressionRegionCode not valid")
 
     #Determine method for each code: "BC" (basin characteristic), "AC" (active channel), "BF" (bankfull width), or "RS" (remote sensing)
     methodCode1 = code1[:2]
@@ -27,12 +26,10 @@ def getCrossCorrelationCoefficient(regressionRegionCode, code1, code2):
     if methodCode2 == "PK":
         methodCode2 = "BC"
     validMethodCodes = ["BC", "AC", "BF", "RS"]
-    if methodCode1 not in validMethodCodes :
-        raise Exception("Method in code1 not valid")
-    if methodCode2 not in validMethodCodes:
-        raise Exception("Method in code2 not valid")
+    if methodCode1 not in validMethodCodes or methodCode2 not in validMethodCodes:
+        raise ValueError("Method in code not valid")
     if methodCode1 == methodCode2:
-        raise Exception("Method codes must be different")
+        raise ValueError("Method in codes must all be unique")
 
     #Determine AEP: a string to describe the peak-flow discharge with annual exceedance probability, ex. "Q42.9"
     isDigitsCode1 = [x.isdigit() for x in code1]
@@ -46,7 +43,7 @@ def getCrossCorrelationCoefficient(regressionRegionCode, code1, code2):
     if code1[firstDigitIndexCode1:lastDigitIndexCode1+1] == code2[firstDigitIndexCode2:lastDigitIndexCode2+1]:
         AEP = "Q" + code1[firstDigitIndexCode1:lastDigitIndexCode1+1].replace("_", ".") 
     else:
-        raise Exception("AEP value must be the same for both flow statistics")
+        raise ValueError("AEP value must be the same for all flow statistics")
 
     #Return the coefficient from the table
     try:
@@ -67,7 +64,6 @@ def weightEst2(x1, x2, SEP1, SEP2, regressionRegionCode, code1, code2):
 
     r12 = getCrossCorrelationCoefficient(regressionRegionCode, code1, code2)
 
-    #Sanity checks
     if((SEP1 <= 0) | (SEP2 <= 0)):
         raise ValueError("All SEP values must be greater than zero")
 
@@ -78,10 +74,6 @@ def weightEst2(x1, x2, SEP1, SEP2, regressionRegionCode, code1, code2):
 
     Z = a1*x1 + a2*x2 #EQ 11
     SEPZ = ((SEP1**2*SEP2**2 - S12**2) / (SEP1**2 + SEP2**2 - 2*S12))**0.5 #EQ 12
-
-    #Check for estimate outside input bounds
-    if ((Z < min(x1, x2)) | (Z > max(x1, x2))):
-        warnings.warn("Weighted value is outside the range of input values. This can occur when the input estimates are highly correlated.")
 
     return((Z, SEPZ)) #Returns weighted estimate Z, and associated SEP
 
@@ -96,7 +88,6 @@ def weightEst3(x1, x2, x3, SEP1, SEP2, SEP3, regressionRegionCode, code1, code2,
     r13 = getCrossCorrelationCoefficient(regressionRegionCode, code1, code3)
     r23 = getCrossCorrelationCoefficient(regressionRegionCode, code2, code3)
 
-    #Sanity checks
     if((SEP1 <= 0) | (SEP2 <= 0) | (SEP3 <= 0)):
         raise ValueError("All SEP values must be greater than zero")
 
@@ -113,11 +104,15 @@ def weightEst3(x1, x2, x3, SEP1, SEP2, SEP3, regressionRegionCode, code1, code2,
     a3 = 1 - a1 - a2 #EQ 8
 
     Z = a1*x1 + a2*x2 + a3*x3 #EQ 5
-
-    #Check for estimate outside input bounds
-    if ((Z < min(x1, x2, x3)) | (Z > max(x1, x2, x3))):
-        warnings.warn("Weighted value is outside the range of input values. This can occur when the input estimates are highly correlated.")
                                 
     SEPZ = ((a1*SEP1)**2 + (a2*SEP2)**2 + (a3*SEP3)**2 + 2*a1*a2*S12 + 2*a1*a3*S13 + 2*a2*a3*S23)**0.5 #EQ 10
 
     return((Z, SEPZ)) #Returns weighted estimate Z, and associated SEP
+
+#Check if the weighted estimate is within the bounds of input values
+def weightingError(Z, x1, x2, x3 = None):
+    #Z is weighted estimate in log units
+    #x1, x2, x3 are input estimates in log units
+    if x3 == None:
+        x3 = x1
+    return ((Z < min(x1, x2, x3)) | (Z > max(x1, x2, x3)))

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from fastapi.responses import RedirectResponse
 from starlette.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
-from ChannelWidthWeighting import weightEst2, weightEst3, weightingError
+from ChannelWidthWeighting import weightEst2, weightEst3
 
 
 app = FastAPI(

--- a/main.py
+++ b/main.py
@@ -103,7 +103,7 @@ def docs_redirect_root():
 def weightest2(request_body: WeightEst2, response: Response):
 
     try: 
-        z, sepz = weightEst2(
+        z, sepz, warningMessage = weightEst2(
             request_body.x1,
             request_body.x2,
             request_body.sep1,
@@ -112,12 +112,8 @@ def weightest2(request_body: WeightEst2, response: Response):
             request_body.code1,
             request_body.code2
         )
-        if weightingError(
-            z,
-            request_body.x1,
-            request_body.x2
-        ):
-            response.headers["warning"] = "Weighted value is outside the range of input values. This can occur when the input estimates are highly correlated."
+        if warningMessage is not None:
+            response.headers["warning"] = warningMessage
         return {
             "Z": z,
             "SEPZ": sepz
@@ -130,7 +126,7 @@ def weightest2(request_body: WeightEst2, response: Response):
 def weightest3(request_body: WeightEst3, response: Response):
 
     try:
-        z, sepz = weightEst3(
+        z, sepz, warningMessage = weightEst3(
             request_body.x1,
             request_body.x2,
             request_body.x3,
@@ -142,13 +138,8 @@ def weightest3(request_body: WeightEst3, response: Response):
             request_body.code2,
             request_body.code3,
         )
-        if weightingError(
-            z,
-            request_body.x1,
-            request_body.x2,
-            request_body.x3,
-        ):
-            response.headers["warning"] = "Weighted value is outside the range of input values. This can occur when the input estimates are highly correlated."
+        if warningMessage is not None:
+            response.headers["warning"] = warningMessage
         return {
             "Z": z,
             "SEPZ": sepz


### PR DESCRIPTION
Closes #2

If the input estimates are too highly correlated, a "warning" message is returned in the response header. Z and SEPZ are still returned in the response body. 

The estimates are too highly correlated when Z is greater than the max of (x1, x2, x3) or when Z is less than the min of (x1, x2, x3). None of the example inputs that were provided actually caused this issue. I ended up just putting `Z = 100000` at the end of the weightEst2 and weightEst3 functions to test it out. 