### PR TITLE
Fixes #16 - Combine all endpoints

### DIFF
--- a/ChannelWidthWeighting.py
+++ b/ChannelWidthWeighting.py
@@ -175,7 +175,7 @@ def weightEst(x1, x2, x3, x4, SEP1, SEP2, SEP3, SEP4, regressionRegionCode, code
     SEPValues = [SEP1, SEP2, SEP3, SEP4]
     codeValues = [code1, code2, code3, code4]
 
-    validValues = [element > 0 for element in xValues] # Boolean list to denote which values are valid (corresponding x values greater than 0)
+    validValues = [element != None for element in xValues] # Boolean list to denote which values are valid (corresponding x values greater than 0)
     numberValidValues = sum(validValues)
 
     xValidValues = [i for (i, v) in zip(xValues, validValues) if v]

--- a/ChannelWidthWeighting.py
+++ b/ChannelWidthWeighting.py
@@ -73,7 +73,7 @@ def weightEst2(x1, x2, SEP1, SEP2, regressionRegionCode, code1, code2):
 	#SEP1, SEP2 are input SEPs in log units
 	#regressionRegionCode is the string code for the Regression Region, ex. "GC1829"
     #code1, code2 are the string codes that describes the flow statistic for the estimation methods, ex. "ACPK0_2AEP", which represents "Active Channel Width 0.2-percent AEP flood"
-
+    
     x1 = math.log10(x1)
     x2 = math.log10(x2)
 
@@ -91,7 +91,7 @@ def weightEst2(x1, x2, SEP1, SEP2, regressionRegionCode, code1, code2):
     SEPZ = ((SEP1**2*SEP2**2 - S12**2) / (SEP1**2 + SEP2**2 - 2*S12))**0.5 #EQ 12
 
     warningMessage = getWeightingErrorMessage(Z, x1, x2)
-
+    
     CI = 1.64 * SEPZ #Confidence interval
     PIL = 10 ** (Z - CI) #Prediction Interval-Lower 
     PIU = 10 ** (Z + CI) #Prediction Interval-Upper
@@ -147,6 +147,7 @@ def weightEst4(x1, x2, x3, x4, SEP1, SEP2, SEP3, SEP4, regressionRegionCode, cod
     #regressionRegionCode is the string code for the Regression Region, ex. "GC1829"
     #code1, code2, code3, code4 are the string codes that describes the flow statistic for the estimation methods, ex. "ACPK0_2AEP", which represents "Active Channel Width 0.2-percent AEP flood"
 
+
     xValues = [x1, x2, x3, x4]
     SEPValues = [SEP1, SEP2, SEP3, SEP4]
     codeValues = [code1, code2, code3, code4]
@@ -164,3 +165,37 @@ def weightEst4(x1, x2, x3, x4, SEP1, SEP2, SEP3, SEP4, regressionRegionCode, cod
     warningMessage += "Only 3 estimation methods can be weighted; the 3 estimation methods with lowest SEP values were weighted. "
 
     return((Z, SEPZ, CI, PIL, PIU, warningMessage)) #Returns weighted estimate Z, associated SEP, and warning messages about results validity
+
+def condition(x):
+    return x > 0
+
+def weightEst(x1, x2, x3, x4, SEP1, SEP2, SEP3, SEP4, regressionRegionCode, code1, code2, code3, code4):
+    #x1, x2, x3, x4 are input estimates
+	#SEP1, SEP2, SEP3, SEP4 are input SEPs in log units
+    #regressionRegionCode is the string code for the Regression Region, ex. "GC1829"
+    #code1, code2, code3, code4 are the string codes that describes the flow statistic for the estimation methods, ex. "ACPK0_2AEP", which represents "Active Channel Width 0.2-percent AEP flood"
+
+    xValues = [x1, x2, x3, x4]
+    SEPValues = [SEP1, SEP2, SEP3, SEP4]
+    codeValues = [code1, code2, code3, code4]
+
+    validValues = [element > 0 for element in xValues]
+    numberValidValues = sum(validValues)
+
+    xValues = [i for (i, v) in zip(xValues, validValues) if v]
+    SEPValues = [i for (i, v) in zip(SEPValues, validValues) if v]
+    codeValues = [i for (i, v) in zip(codeValues, validValues) if v]
+
+    print(xValues)
+    print(SEPValues)
+    print(codeValues)
+
+    if (numberValidValues == 1):
+        raise ValueError("At least one estimation method value must be provided.")
+    elif (numberValidValues == 2):
+        return weightEst2(*xValues, *SEPValues, regressionRegionCode, *codeValues)
+    elif (numberValidValues == 3):
+        return weightEst3(*xValues, *SEPValues, regressionRegionCode, *codeValues)
+    elif (numberValidValues == 4):
+        return weightEst4(*xValues, *SEPValues, regressionRegionCode, *codeValues)
+

--- a/ChannelWidthWeighting.py
+++ b/ChannelWidthWeighting.py
@@ -99,7 +99,6 @@ def weightEst2(x1, x2, SEP1, SEP2, regressionRegionCode, code1, code2):
 
     return((Z, SEPZ, CI, PIL, PIU, warningMessage)) #Returns weighted estimate Z, associated SEP, and warning messages about results validity
 
-
 def weightEst3(x1, x2, x3, SEP1, SEP2, SEP3, regressionRegionCode, code1, code2, code3):
     #x1, x2, x3 are input estimates
 	#SEP1, SEP2, SEP3 are input SEPs in log units
@@ -147,7 +146,6 @@ def weightEst4(x1, x2, x3, x4, SEP1, SEP2, SEP3, SEP4, regressionRegionCode, cod
     #regressionRegionCode is the string code for the Regression Region, ex. "GC1829"
     #code1, code2, code3, code4 are the string codes that describes the flow statistic for the estimation methods, ex. "ACPK0_2AEP", which represents "Active Channel Width 0.2-percent AEP flood"
 
-
     xValues = [x1, x2, x3, x4]
     SEPValues = [SEP1, SEP2, SEP3, SEP4]
     codeValues = [code1, code2, code3, code4]
@@ -164,11 +162,9 @@ def weightEst4(x1, x2, x3, x4, SEP1, SEP2, SEP3, SEP4, regressionRegionCode, cod
         warningMessage = ""
     warningMessage += "Only 3 estimation methods can be weighted; the 3 estimation methods with lowest SEP values were weighted. "
 
-    return((Z, SEPZ, CI, PIL, PIU, warningMessage)) #Returns weighted estimate Z, associated SEP, and warning messages about results validity
+    return(Z, SEPZ, CI, PIL, PIU, warningMessage) #Returns weighted estimate Z, associated SEP, and warning messages about results validity
 
-def condition(x):
-    return x > 0
-
+# This single endpoint will pass the inputs to weightEst2, weightEst3, or weightEst4, depending on the number of valid x values (values > 0)
 def weightEst(x1, x2, x3, x4, SEP1, SEP2, SEP3, SEP4, regressionRegionCode, code1, code2, code3, code4):
     #x1, x2, x3, x4 are input estimates
 	#SEP1, SEP2, SEP3, SEP4 are input SEPs in log units
@@ -179,23 +175,18 @@ def weightEst(x1, x2, x3, x4, SEP1, SEP2, SEP3, SEP4, regressionRegionCode, code
     SEPValues = [SEP1, SEP2, SEP3, SEP4]
     codeValues = [code1, code2, code3, code4]
 
-    validValues = [element > 0 for element in xValues]
+    validValues = [element > 0 for element in xValues] # Boolean list to denote which values are valid (corresponding x values greater than 0)
     numberValidValues = sum(validValues)
 
-    xValues = [i for (i, v) in zip(xValues, validValues) if v]
-    SEPValues = [i for (i, v) in zip(SEPValues, validValues) if v]
-    codeValues = [i for (i, v) in zip(codeValues, validValues) if v]
+    xValidValues = [i for (i, v) in zip(xValues, validValues) if v]
+    SEPValidValues = [i for (i, v) in zip(SEPValues, validValues) if v]
+    codeValidValues = [i for (i, v) in zip(codeValues, validValues) if v]
 
-    print(xValues)
-    print(SEPValues)
-    print(codeValues)
-
-    if (numberValidValues == 1):
-        raise ValueError("At least one estimation method value must be provided.")
+    if (numberValidValues < 2):
+        raise ValueError("At least two estimation method values must be provided.")
     elif (numberValidValues == 2):
-        return weightEst2(*xValues, *SEPValues, regressionRegionCode, *codeValues)
+        return weightEst2(*xValidValues, *SEPValidValues, regressionRegionCode, *codeValidValues)
     elif (numberValidValues == 3):
-        return weightEst3(*xValues, *SEPValues, regressionRegionCode, *codeValues)
+        return weightEst3(*xValidValues, *SEPValidValues, regressionRegionCode, *codeValidValues)
     elif (numberValidValues == 4):
-        return weightEst4(*xValues, *SEPValues, regressionRegionCode, *codeValues)
-
+         return weightEst4(*xValidValues, *SEPValidValues, regressionRegionCode, *codeValidValues)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ pip install -r requirements.txt
 uvicorn main:app --host 0.0.0.0 --port 8000
 ```
 
+Alternate instructions for the Windows Anaconda3 prompt:
+
+```bash
+# create a new Conda environment
+conda create --name sc-runoffmodelingservices
+# active the Conda environment
+conda activate sc-runoffmodelingservices
+# install the project's dependencies
+conda install pip
+pip install -r requirements.txt
+# deploy at a local server
+uvicorn main:app --host 0.0.0.0 --port 8000
+```
+
 Once the above code has been run successfully, the service documentation will be available at http://127.0.0.1:8000/docs/.
 
 You can make an example `POST` call to http://127.0.0.1:8000/weightest with the following JSON body representing the inputs:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ uvicorn main:app --host 0.0.0.0 --port 8000
 
 Once the above code has been run successfully, the service documentation will be available at http://127.0.0.1:8000/docs/.
 
+You can make an example `POST` call to http://127.0.0.1:8000/weightest with the following JSON body representing the inputs:
+
+```text
+{"x1": 549.54, "x2": -9999, "x3": -9999, "x4": 398.11, "sep1": 0.234, "sep4": 0.299, "regressionRegionCode": "GC1851", "code1": "PK1AEP", "code4": "RSPK1AEP"}
+```
+
 You can make an example `POST` call to http://127.0.0.1:8000/weightest2 with the following JSON body representing the inputs:
 
 ```text

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Once the above code has been run successfully, the service documentation will be
 You can make an example `POST` call to http://127.0.0.1:8000/weightest with the following JSON body representing the inputs:
 
 ```text
-{"x1": 549.54, "x2": -9999, "x3": -9999, "x4": 398.11, "sep1": 0.234, "sep4": 0.299, "regressionRegionCode": "GC1851", "code1": "PK1AEP", "code4": "RSPK1AEP"}
+{"x1": 549.54, "x2": null, "x3": null, "x4": 398.11, "sep1": 0.234, "sep2": null, "sep3": null, "sep4": 0.299, "regressionRegionCode": "GC1851", "code1": "PK1AEP", "code2": null, "code3": null, "code4": "RSPK1AEP"}
 ```
 
 You can make an example `POST` call to http://127.0.0.1:8000/weightest2 with the following JSON body representing the inputs:

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from fastapi.responses import RedirectResponse
 from starlette.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
-from ChannelWidthWeighting import weightEst2, weightEst3, weightEst4
+from ChannelWidthWeighting import weightEst, weightEst2, weightEst3, weightEst4
 
 
 app = FastAPI(
@@ -19,7 +19,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
 
 ######
 ##
@@ -116,7 +115,7 @@ class WeightEst4(BaseModel):
                 "regressionRegionCode": "GC1851",
                 "code1": "PK1AEP",
                 "code2": "ACPK1AEP",
-                "code3": "BFPK1AEP",
+                "code3": "BWPK1AEP",
                 "code4": "RSPK1AEP"
             }
         }
@@ -134,6 +133,36 @@ class WeightEst4(BaseModel):
 def docs_redirect_root():
     return RedirectResponse(url=app.docs_url)
 
+@app.post("/weightest/")
+def weightest4(request_body: WeightEst4, response: Response):
+
+    try:
+        Z, SEPZ, CI, PIL, PIU, warningMessage  = weightEst(
+            request_body.x1,
+            request_body.x2,
+            request_body.x3,
+            request_body.x4,
+            request_body.sep1,
+            request_body.sep2,
+            request_body.sep3,
+            request_body.sep4,
+            request_body.regressionRegionCode,
+            request_body.code1,
+            request_body.code2,
+            request_body.code3,
+            request_body.code4,
+        )
+        response.headers["warning"] = warningMessage
+        return {
+            "Z": Z,
+            "SEPZ": SEPZ,
+            "CI": CI,
+            "PIL": PIL,
+            "PIU": PIU
+        }
+
+    except Exception as e:
+        raise HTTPException(status_code = 500, detail =  str(e))
 
 @app.post("/weightest2/")
 def weightest2(request_body: WeightEst2, response: Response):

--- a/main.py
+++ b/main.py
@@ -120,6 +120,37 @@ class WeightEst4(BaseModel):
             }
         }
 
+class WeightEst(BaseModel):
+
+    x1: float = -9999
+    x2: float = -9999
+    x3: float = -9999
+    x4: float = -9999
+    sep1: float = -9999
+    sep2: float = -9999
+    sep3: float = -9999
+    sep4: float = -9999
+    regressionRegionCode: str
+    code1: str = "-9999"
+    code2: str = "-9999"
+    code3: str = "-9999"
+    code4: str = "-9999"
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "x1": 549.54,
+                "x2": -9999,
+                "x3": -9999,
+                "x4": 398.11,
+                "sep1": 0.234,
+                "sep4": 0.299,
+                "regressionRegionCode": "GC1851",
+                "code1": "PK1AEP",
+                "code4": "RSPK1AEP"
+            }
+        }
+
 
 ######
 ##
@@ -134,7 +165,7 @@ def docs_redirect_root():
     return RedirectResponse(url=app.docs_url)
 
 @app.post("/weightest/")
-def weightest(request_body: WeightEst4, response: Response):
+def weightest(request_body: WeightEst, response: Response):
 
     try:
         Z, SEPZ, CI, PIL, PIU, warningMessage  = weightEst(

--- a/main.py
+++ b/main.py
@@ -134,7 +134,7 @@ def docs_redirect_root():
     return RedirectResponse(url=app.docs_url)
 
 @app.post("/weightest/")
-def weightest4(request_body: WeightEst4, response: Response):
+def weightest(request_body: WeightEst4, response: Response):
 
     try:
         Z, SEPZ, CI, PIL, PIU, warningMessage  = weightEst(
@@ -152,7 +152,8 @@ def weightest4(request_body: WeightEst4, response: Response):
             request_body.code3,
             request_body.code4,
         )
-        response.headers["warning"] = warningMessage
+        if warningMessage is not None:
+            response.headers["warning"] = warningMessage
         return {
             "Z": Z,
             "SEPZ": SEPZ,

--- a/main.py
+++ b/main.py
@@ -1,7 +1,9 @@
+from urllib import request
 from fastapi import FastAPI, HTTPException, Response
 from fastapi.responses import RedirectResponse
 from starlette.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+from pydantic.schema import Optional
 
 from ChannelWidthWeighting import weightEst, weightEst2, weightEst3, weightEst4
 
@@ -28,6 +30,42 @@ app.add_middleware(
 
 # These schemas provide format and data type validation
 #  of request body inputs, and automated API documentation
+
+class WeightEst(BaseModel):
+
+    x1: Optional[float]
+    x2: Optional[float]
+    x3: Optional[float]
+    x4: Optional[float]
+    sep1: Optional[float]
+    sep2: Optional[float]
+    sep3: Optional[float]
+    sep4: Optional[float]
+    regressionRegionCode: str
+    code1: Optional[str]
+    code2: Optional[str]
+    code3: Optional[str]
+    code4: Optional[str]
+
+    class Config:
+        null = None
+        schema_extra = {
+            "example": {
+                "x1": 549.54,
+                "x2": null,
+                "x3": null,
+                "x4": 398.11,
+                "sep1": 0.234,
+                "sep2": null,
+                "sep3": null,
+                "sep4": 0.299,
+                "regressionRegionCode": "GC1851",
+                "code1": "PK1AEP",
+                "code2": null,
+                "code3": null,
+                "code4": "RSPK1AEP"
+            }
+        }
 
 class WeightEst2(BaseModel):
 
@@ -119,38 +157,6 @@ class WeightEst4(BaseModel):
                 "code4": "RSPK1AEP"
             }
         }
-
-class WeightEst(BaseModel):
-
-    x1: float = -9999
-    x2: float = -9999
-    x3: float = -9999
-    x4: float = -9999
-    sep1: float = -9999
-    sep2: float = -9999
-    sep3: float = -9999
-    sep4: float = -9999
-    regressionRegionCode: str
-    code1: str = "-9999"
-    code2: str = "-9999"
-    code3: str = "-9999"
-    code4: str = "-9999"
-
-    class Config:
-        schema_extra = {
-            "example": {
-                "x1": 549.54,
-                "x2": -9999,
-                "x3": -9999,
-                "x4": 398.11,
-                "sep1": 0.234,
-                "sep4": 0.299,
-                "regressionRegionCode": "GC1851",
-                "code1": "PK1AEP",
-                "code4": "RSPK1AEP"
-            }
-        }
-
 
 ######
 ##


### PR DESCRIPTION
Closes #16 

The new `weightest` endpoint will pass the input values along to the proper weightEst2, weightEst3, or weightEst4 endpoints, depending on the number of x values that are not `null`.

Error 500 is returned if there are less than 2 x-values that are not `null`.

How the code works:
- It looks at which x values are not `null`: x1, x2, x3, and/or x4
- The x values that are `null`, and their corresponding SEP and code values, are thrown out. For example, if x2 and x3 are `null`, SEP2, SEP3, code2, and code3 are thrown out, regardless of their value.
- The code passes the values along to weightEst2, weightEst3, or weightEst4, depending on the number of x values that were not `null`
- Note: `regressionRegionCode` is the only required input parameter. All other values will default to null. 
