### PR TITLE
Fixes #19 - Improve error returns for invalid SEP values 

### DIFF
--- a/ChannelWidthWeighting.py
+++ b/ChannelWidthWeighting.py
@@ -74,6 +74,16 @@ def weightEst2(x1, x2, SEP1, SEP2, regressionRegionCode, code1, code2):
 	#regressionRegionCode is the string code for the Regression Region, ex. "GC1829"
     #code1, code2 are the string codes that describes the flow statistic for the estimation methods, ex. "ACPK0_2AEP", which represents "Active Channel Width 0.2-percent AEP flood"
     
+    # Check that all x values are valid (not null)
+    if None in [x1, x2]:
+        raise ValueError("Two estimation method values must be provided.")
+    # Check that all SEP values are valid (not null)
+    if None in [SEP1, SEP2]:
+        raise ValueError("Two SEP values must be provided.")
+    # Check that all code values are valid (not null)
+    if None in [code1, code2]:
+        raise ValueError("Two code values must be provided.")
+
     x1 = math.log10(x1)
     x2 = math.log10(x2)
 
@@ -104,6 +114,16 @@ def weightEst3(x1, x2, x3, SEP1, SEP2, SEP3, regressionRegionCode, code1, code2,
 	#SEP1, SEP2, SEP3 are input SEPs in log units
     #regressionRegionCode is the string code for the Regression Region, ex. "GC1829"
     #code1, code2, code3 are the string codes that describes the flow statistic for the estimation methods, ex. "ACPK0_2AEP", which represents "Active Channel Width 0.2-percent AEP flood"
+
+    # Check that all x values are valid (not null)
+    if None in [x1, x2, x3]:
+        raise ValueError("Three estimation method values must be provided.")
+    # Check that all SEP values are valid (not null)
+    if None in [SEP1, SEP2, SEP3]:
+        raise ValueError("Three SEP values must be provided.")
+    # Check that all code values are valid (not null)
+    if None in [code1, code2, code3]:
+        raise ValueError("Three code values must be provided.")
 
     x1 = math.log10(x1)
     x2 = math.log10(x2)
@@ -156,6 +176,16 @@ def weightEst4(x1, x2, x3, x4, SEP1, SEP2, SEP3, SEP4, regressionRegionCode, cod
     SEPValues.pop(maxSEPIndex)
     codeValues.pop(maxSEPIndex)
 
+    # Check that there are 3 remaining valid x values that (not null) 
+    if None in xValues:
+        raise ValueError("At least two estimation method values must be provided.")
+    # Check that corresponding SEP values are all valid (not null)
+    if None in SEPValues:
+        raise ValueError("SEP values were unavailable for corresponding flow statistic values.")
+    # Check that corresponding code values are all valid (not null)
+    if None in codeValues:
+        raise ValueError("Code values were unavailable for corresponding flow statistic values.")
+
     Z, SEPZ, CI, PIL, PIU, warningMessage = weightEst3(*xValues, *SEPValues, regressionRegionCode, *codeValues) #Returns weighted estimate Z, associated SEP, and warning messages about results validity
 
     if warningMessage is None:
@@ -182,9 +212,11 @@ def weightEst(x1, x2, x3, x4, SEP1, SEP2, SEP3, SEP4, regressionRegionCode, code
     SEPValidValues = [i for (i, v) in zip(SEPValues, validValues) if v]
     codeValidValues = [i for (i, v) in zip(codeValues, validValues) if v]
 
-    # Check that valid values are not all null
+    # Check that corresponding SEP values are all valid (not null)
     if None in SEPValidValues:
         raise ValueError("SEP values were unavailable for corresponding flow statistic values.")
+    if None in codeValidValues:
+        raise ValueError("Code values were unavailable for corresponding flow statistic values.")
 
     if (numberValidValues < 2):
         raise ValueError("At least two estimation method values must be provided.")

--- a/ChannelWidthWeighting.py
+++ b/ChannelWidthWeighting.py
@@ -9,7 +9,7 @@ def getCrossCorrelationCoefficient(regressionRegionCode, code1, code2):
     #code1, code2 ares the string codes that describes the flow statistic for the estimation methods, ex. "ACPK0_2AEP", which represents "Active Channel Width 0.2-percent AEP flood"
 
     if code1 == code2:
-        raise ValueError("codes must all be unique")
+        raise ValueError("codes must all be unique.")
 
     #Determine hydrologic region that contains this Regression Region
     hydrologicRegionName = None
@@ -17,7 +17,7 @@ def getCrossCorrelationCoefficient(regressionRegionCode, code1, code2):
         if regressionRegionCode in regressionRegionCodes:
             hydrologicRegionName = hydrologicRegion
     if hydrologicRegionName == None:
-        raise ValueError("regressionRegionCode not valid")
+        raise ValueError("regressionRegionCode not valid.")
 
     #Determine method for each code: "BC" (basin characteristic), "AC" (active channel), "BW" (bankfull width), or "RS" (remote sensing)
     methodCode1 = code1[:2]
@@ -28,9 +28,9 @@ def getCrossCorrelationCoefficient(regressionRegionCode, code1, code2):
         methodCode2 = "BC"
     validMethodCodes = ["BC", "AC", "BW", "RS"]
     if methodCode1 not in validMethodCodes or methodCode2 not in validMethodCodes:
-        raise ValueError("Method in code not valid")
+        raise ValueError("Method in code not valid.")
     if methodCode1 == methodCode2:
-        raise ValueError("Method in codes must all be unique")
+        raise ValueError("Method in codes must all be unique.")
 
     #Determine AEP: a string to describe the peak-flow discharge with annual exceedance probability, ex. "Q42.9"
     isDigitsCode1 = [x.isdigit() for x in code1]
@@ -44,7 +44,7 @@ def getCrossCorrelationCoefficient(regressionRegionCode, code1, code2):
     if code1[firstDigitIndexCode1:lastDigitIndexCode1+1] == code2[firstDigitIndexCode2:lastDigitIndexCode2+1]:
         AEP = "Q" + code1[firstDigitIndexCode1:lastDigitIndexCode1+1].replace("_", ".") 
     else:
-        raise ValueError("AEP value must be the same for all flow statistics")
+        raise ValueError("AEP value must be the same for all flow statistics.")
 
     #Return the coefficient from the table
     try:
@@ -53,7 +53,7 @@ def getCrossCorrelationCoefficient(regressionRegionCode, code1, code2):
         try:
             coefficient = crossCorrelationCoefficientTable[hydrologicRegionName][methodCode2 + "," + methodCode1][AEP]
         except:
-            raise Exception("Coefficient could not be determined")
+            raise Exception("Coefficient could not be determined.")
     finally: 
         return coefficient
 
@@ -80,7 +80,7 @@ def weightEst2(x1, x2, SEP1, SEP2, regressionRegionCode, code1, code2):
     r12 = getCrossCorrelationCoefficient(regressionRegionCode, code1, code2)
 
     if((SEP1 <= 0) | (SEP2 <= 0)):
-        raise ValueError("All SEP values must be greater than zero")
+        raise ValueError("All SEP values must be greater than zero.")
 
     S12 = r12*(SEP1*SEP2) 
 
@@ -114,7 +114,7 @@ def weightEst3(x1, x2, x3, SEP1, SEP2, SEP3, regressionRegionCode, code1, code2,
     r23 = getCrossCorrelationCoefficient(regressionRegionCode, code2, code3)
 
     if((SEP1 <= 0) | (SEP2 <= 0) | (SEP3 <= 0)):
-        raise ValueError("All SEP values must be greater than zero")
+        raise ValueError("All SEP values must be greater than zero.")
 
     S12 = r12*(SEP1*SEP2) 
     S13 = r13*(SEP1*SEP3)
@@ -181,6 +181,10 @@ def weightEst(x1, x2, x3, x4, SEP1, SEP2, SEP3, SEP4, regressionRegionCode, code
     xValidValues = [i for (i, v) in zip(xValues, validValues) if v]
     SEPValidValues = [i for (i, v) in zip(SEPValues, validValues) if v]
     codeValidValues = [i for (i, v) in zip(codeValues, validValues) if v]
+
+    # Check that valid values are not all null
+    if not any(SEPValidValues):
+        raise ValueError("SEP values were unavailable for corresponding flow statistic values.")
 
     if (numberValidValues < 2):
         raise ValueError("At least two estimation method values must be provided.")

--- a/ChannelWidthWeighting.py
+++ b/ChannelWidthWeighting.py
@@ -183,7 +183,7 @@ def weightEst(x1, x2, x3, x4, SEP1, SEP2, SEP3, SEP4, regressionRegionCode, code
     codeValidValues = [i for (i, v) in zip(codeValues, validValues) if v]
 
     # Check that valid values are not all null
-    if not any(SEPValidValues):
+    if None in SEPValidValues:
         raise ValueError("SEP values were unavailable for corresponding flow statistic values.")
 
     if (numberValidValues < 2):

--- a/ChannelWidthWeighting.py
+++ b/ChannelWidthWeighting.py
@@ -74,16 +74,6 @@ def weightEst2(x1, x2, SEP1, SEP2, regressionRegionCode, code1, code2):
 	#regressionRegionCode is the string code for the Regression Region, ex. "GC1829"
     #code1, code2 are the string codes that describes the flow statistic for the estimation methods, ex. "ACPK0_2AEP", which represents "Active Channel Width 0.2-percent AEP flood"
     
-    # Check that all x values are valid (not null)
-    if None in [x1, x2]:
-        raise ValueError("Two estimation method values must be provided.")
-    # Check that all SEP values are valid (not null)
-    if None in [SEP1, SEP2]:
-        raise ValueError("Two SEP values must be provided.")
-    # Check that all code values are valid (not null)
-    if None in [code1, code2]:
-        raise ValueError("Two code values must be provided.")
-
     x1 = math.log10(x1)
     x2 = math.log10(x2)
 
@@ -114,16 +104,6 @@ def weightEst3(x1, x2, x3, SEP1, SEP2, SEP3, regressionRegionCode, code1, code2,
 	#SEP1, SEP2, SEP3 are input SEPs in log units
     #regressionRegionCode is the string code for the Regression Region, ex. "GC1829"
     #code1, code2, code3 are the string codes that describes the flow statistic for the estimation methods, ex. "ACPK0_2AEP", which represents "Active Channel Width 0.2-percent AEP flood"
-
-    # Check that all x values are valid (not null)
-    if None in [x1, x2, x3]:
-        raise ValueError("Three estimation method values must be provided.")
-    # Check that all SEP values are valid (not null)
-    if None in [SEP1, SEP2, SEP3]:
-        raise ValueError("Three SEP values must be provided.")
-    # Check that all code values are valid (not null)
-    if None in [code1, code2, code3]:
-        raise ValueError("Three code values must be provided.")
 
     x1 = math.log10(x1)
     x2 = math.log10(x2)
@@ -175,16 +155,6 @@ def weightEst4(x1, x2, x3, x4, SEP1, SEP2, SEP3, SEP4, regressionRegionCode, cod
     xValues.pop(maxSEPIndex)
     SEPValues.pop(maxSEPIndex)
     codeValues.pop(maxSEPIndex)
-
-    # Check that there are 3 remaining valid x values that (not null) 
-    if None in xValues:
-        raise ValueError("At least two estimation method values must be provided.")
-    # Check that corresponding SEP values are all valid (not null)
-    if None in SEPValues:
-        raise ValueError("SEP values were unavailable for corresponding flow statistic values.")
-    # Check that corresponding code values are all valid (not null)
-    if None in codeValues:
-        raise ValueError("Code values were unavailable for corresponding flow statistic values.")
 
     Z, SEPZ, CI, PIL, PIU, warningMessage = weightEst3(*xValues, *SEPValues, regressionRegionCode, *codeValues) #Returns weighted estimate Z, associated SEP, and warning messages about results validity
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ You can make an example `POST` call to http://127.0.0.1:8000/weightest4 with the
 - **[Seth Siefen](https://www.usgs.gov/staff-profiles/seth-siefken)** - *Channel Width Weighting Script Author* - [USGS Wyoming-Montana Water Science Center](https://www.usgs.gov/centers/wyoming-montana-water-science-center/)
 - **[Aaron Stephenson](https://github.com/aaronstephenson)**  - *Web Developer* - [USGS Web Informatics & Mapping](https://wim.usgs.gov/)
 - **[Andrea Medenblik](https://github.com/amedenblik)**  - *Web Developer* - [USGS Web Informatics & Mapping](https://wim.usgs.gov/)
+- **[Harper Wavra](https://github.com/harper-wavra)**  - *Web Developer* - [USGS Web Informatics & Mapping](https://wim.usgs.gov/)
 
 See also the list of [contributors](../../graphs/contributors) who participated in this project.
 

--- a/main.py
+++ b/main.py
@@ -1,9 +1,9 @@
-from urllib import request
 from fastapi import FastAPI, HTTPException, Response
 from fastapi.responses import RedirectResponse
 from starlette.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from pydantic.schema import Optional
+import json
 
 from ChannelWidthWeighting import weightEst, weightEst2, weightEst3, weightEst4
 
@@ -190,7 +190,8 @@ def weightest(request_body: WeightEst, response: Response):
             request_body.code4,
         )
         if warningMessage is not None:
-            response.headers["warning"] = warningMessage
+            response.headers["X-USGSWIM-Messages"] = json.dumps({'warning': warningMessage})
+        response.headers["Access-Control-Expose-Headers"] = "X-USGSWIM-Messages"
         return {
             "Z": Z,
             "SEPZ": SEPZ,
@@ -216,7 +217,8 @@ def weightest2(request_body: WeightEst2, response: Response):
             request_body.code2
         )
         if warningMessage is not None:
-            response.headers["warning"] = warningMessage
+            response.headers["X-USGSWIM-Messages"] = json.dumps({'warning': warningMessage})
+        response.headers["Access-Control-Expose-Headers"] = "X-USGSWIM-Messages"
         return {
             "Z": Z,
             "SEPZ": SEPZ,
@@ -245,7 +247,8 @@ def weightest3(request_body: WeightEst3, response: Response):
             request_body.code3
         )
         if warningMessage is not None:
-            response.headers["warning"] = warningMessage
+            response.headers["X-USGSWIM-Messages"] = json.dumps({'warning': warningMessage})
+        response.headers["Access-Control-Expose-Headers"] = "X-USGSWIM-Messages"
         return {
             "Z": Z,
             "SEPZ": SEPZ,
@@ -277,7 +280,9 @@ def weightest4(request_body: WeightEst4, response: Response):
             request_body.code3,
             request_body.code4,
         )
-        response.headers["warning"] = warningMessage
+        if warningMessage is not None:
+            response.headers["X-USGSWIM-Messages"] = json.dumps({'warning': warningMessage})
+        response.headers["Access-Control-Expose-Headers"] = "X-USGSWIM-Messages"
         return {
             "Z": Z,
             "SEPZ": SEPZ,


### PR DESCRIPTION
Example: https://ss-weightingservices.streamstats.usgs.gov/weightest/

POST body:
{"x1":2140,"x2":92700,"x3":1270,"x4":1150,"sep1":0.3436910729820962,"sep2":null,"sep3":0.3540051559817674,"sep4":0.41478910303912275,"regressionRegionCode":"GC1849","code1":"ACPK0_5AEP","code2":"PK0_5AEP","code3":"BWPK0_5AEP","code4":"RSPK0_5AEP"}

Now returns the message `"SEP values were unavailable for corresponding flow statistic values."`

This only applies to the `weightest` endpoint because the other endpoints require all inputs to be not null.

Should help with https://github.com/USGS-WiM/StreamStats/issues/1161